### PR TITLE
Bug: Fix bug on Fetch Article by Page Number 

### DIFF
--- a/server/routes/get-articles.routes.js
+++ b/server/routes/get-articles.routes.js
@@ -4,6 +4,6 @@ import Articles from '../controllers/get-articles.controllers';
 
 const router = express.Router();
 
-router.use('/articles/:page', Articles.getArticles);
+router.get('/articles/:page', Articles.getArticles);
 
 export default router;


### PR DESCRIPTION
#### Description
Currently, the controller `get-articles.controller` is using `router.use`. This `PR` corrects that, changing it to `router.get`

#### Type of change

- [ ] Bug fix

#### How Has This Been Tested?

- [ ] Unit testing

#### Checklist:
N/A

#### PT-ID
N/A

#### Screenshots
N/A

#### Questions:
N/A
