### PR TITLE
Bug: fix bug on admin controller

### DIFF
--- a/server/controllers/admin.controllers.js
+++ b/server/controllers/admin.controllers.js
@@ -36,10 +36,10 @@ const activateReviewer = async (req, res) => {
         is_reviewer: true,
       });
 
-      const upgradeUser = profileHelper.profiler(userUpgrade);
+      const userDetails = profileHelper.profiler(userUpgrade);
       return res.status(200).json({
         message: 'You have granted a user reviewer access',
-        user: upgradeUser,
+        user: userDetails,
       });
     }
     return res.status(403).json({
@@ -77,10 +77,10 @@ const deactivateReviewer = async (req, res) => {
     // Deactivate user reveiwer access
     if (findUser) {
       const downgradeUser = await findUser.update({ is_reviewer: false });
-      const downgadeUser = profileHelper.profiler(downgradeUser);
+      const userDetails = profileHelper.profiler(downgradeUser);
       return res.status(200).json({
         message: 'You have removed a user reviewer access',
-        user: downgadeUser,
+        user: userDetails,
       });
     }
     return res.status(403).json({


### PR DESCRIPTION
#### Description
Currently, when an admin activates a user to become a reviewer, the user details returns with his/her password. For security concern, the password should not return. This PR eliminates users password from returning when an admin activates a user.
#### Type of change

- [x] Bug fix(admin controller)
#### How Has This Been Tested?

- [x] End to End testing

#### Checklist:
N/A

#### PT-ID
**Before fix**
![image](https://user-images.githubusercontent.com/33469121/56152561-f40c3d80-5fab-11e9-9582-6c0f4e25cc2e.png)
![image](https://user-images.githubusercontent.com/33469121/56152582-fff7ff80-5fab-11e9-8898-d5968867b86e.png)
**After fix**
![image](https://user-images.githubusercontent.com/33469121/56152608-13a36600-5fac-11e9-88d3-a5fe92a775b9.png)
![image](https://user-images.githubusercontent.com/33469121/56152621-1b630a80-5fac-11e9-9e09-84d181a9a8af.png)


#### Questions:
N/A