### PR TITLE
chore(bookmark): add author info to returned articles

### DIFF
--- a/server/controllers/bookmark.controller.js
+++ b/server/controllers/bookmark.controller.js
@@ -79,6 +79,13 @@ const getBookMarkedArticlesForUser = async (req, res) => {
             'likes_count',
             'reading_time',
           ],
+          include: [
+            {
+              model: User,
+              as: 'author',
+              attributes: ['first_name', 'last_name'],
+            },
+          ],
         },
       ],
     });

--- a/server/models/bookmark.js
+++ b/server/models/bookmark.js
@@ -42,6 +42,7 @@ module.exports = (sequelize, DataTypes) => {
     });
     Bookmark.belongsTo(models.User, {
       foreignKey: 'user_id',
+      as: 'author',
     });
   };
   return Bookmark;


### PR DESCRIPTION
#### Description
Currently, the get bookmark endpoint does not return the author's information with the articles. This `PR` add the author's information to the return data. 

#### Type of change

- [x] None breaking

#### How Has This Been Tested?

- [x] Unit testing

#### Checklist:
N/A

#### PT-ID

N/A

#### Screenshots

<img width="1116" alt="Screenshot 2019-05-16 at 7 00 24 PM" src="https://user-images.githubusercontent.com/17157020/57876290-ea753000-780c-11e9-92b1-ae902c4ce060.png">


#### Questions:
N/A